### PR TITLE
raise IOError if response is error

### DIFF
--- a/simple_acme.py
+++ b/simple_acme.py
@@ -59,7 +59,7 @@ def _send_signed_request(user, url, payload):
         return resp.getcode(), resp.read(), resp.info()
     except IOError as e:
         LE_NONCE = e.info().getheader('Replay-Nonce', None)
-        return e.code, e.read(), e.info()
+        raise IOError("Unexpected response: {}".format(e.read()))
 
 
 class AcmeUser:


### PR DESCRIPTION
If the _send_signed_request method had a problem, the script would encounter a "expected string or buffer" warning. This raises an IOError instead, so that useful information is logged and the script fails.

In my case, it turns out that I was hitting a rate limit. This is the new output, taken from my Lambda logs:

```
[WARNING]   2016-06-24T17:02:36.3Z   Unexpected response: {
  "type": "urn:acme:error:rateLimited",
  "detail": "Error creating new cert :: Too many certificates already issued for exact set of domains: media-test.example.com,media.example.com",
  "status": 429
}
```

Also, FWIW, the changes in #14 were required for me to get this far in the process.
