### PR TITLE
Add missing parameters for CloudFront UpdateDistribution

### DIFF
--- a/lambda_function.py
+++ b/lambda_function.py
@@ -470,6 +470,7 @@ def configure_cloudfront(domain, s3bucket):
             'DomainName': '{}.s3.amazonaws.com'.format(s3bucket),
             'Id': 'lambda-letsencrypt-challenges',
             'OriginPath': "/{}".format(domain['CLOUDFRONT_ID']),
+            'CustomHeaders': {u'Quantity': 0},
             'S3OriginConfig': {u'OriginAccessIdentity': ''}
         })
 
@@ -493,7 +494,10 @@ def configure_cloudfront(domain, s3bucket):
             'ForwardedValues': {
                 u'Cookies': {u'Forward': 'none'},
                 'Headers': {'Quantity': 0},
-                'QueryString': False
+                'QueryString': False,
+                'QueryStringCacheKeys': {
+                    'Quantity': 0
+                }
             },
             'MaxTTL': 31536000,
             'MinTTL': 0,


### PR DESCRIPTION
`CustomHeaders` and `QueryStringCacheKeys` parameters are added to appropriate places, as they are now required for CloudFront UpdateDistribution operation.

Tested against my S3/CloudFront distribution today and works ok.
