### PR TITLE
delete and retry expired authorizations

### DIFF
--- a/simple_acme.py
+++ b/simple_acme.py
@@ -253,6 +253,9 @@ class AcmeAuthorization:
             for c in result['challenges']:
                 if 'error' in c:
                     logger.debug(c['error']['detail'])
+        elif status == 404 and result['detail'] == 'Expired authorization':
+            status = 'expired'
+
         return status
 
     def complete_challenges(self, challenge_type, func_challenge, func_verifier):


### PR DESCRIPTION
If an authorization challenge for a domain has expired, LetsEncrypt returns a response like:

> {'status': 404, 'type': u'urn:acme:error:malformed', 'detail': u'Expired authorization'}

In this event, the code will now delete the domain's config file from S3 and retry the `authorize_domain` call, which will create a new authorization challenge.